### PR TITLE
fix Android 10 and above .text segment is read-only by default

### DIFF
--- a/And64InlineHook.cpp
+++ b/And64InlineHook.cpp
@@ -581,7 +581,10 @@ extern "C" {
             *result = trampoline;
             if (trampoline == NULL) return;
         } //if
-
+        
+        //fix Android 10 .text segment is read-only by default
+        __make_rwx(symbol, 5 * sizeof(size_t));
+        
         trampoline = A64HookFunctionV(symbol, replace, trampoline, A64_MAX_INSTRUCTIONS * 10u);
         if (trampoline == NULL && result != NULL) {
             *result = NULL;


### PR DESCRIPTION
On Android 10 an above,the .text segment is read-only by default
![image](https://user-images.githubusercontent.com/3992446/114297848-a288e180-9ae5-11eb-8efc-6eee97fbae55.png)
so fix it  by make it readable pre hooking