### PR TITLE
Bug fix.

### DIFF
--- a/And64InlineHook.cpp
+++ b/And64InlineHook.cpp
@@ -202,7 +202,7 @@ static bool __fix_cond_comp_test_branch(instruction inpp, instruction outpp, con
     } //if
 
     intptr_t current_idx  = ctxp->get_and_set_current_index(*inpp, *outpp);
-    int64_t absolute_addr = reinterpret_cast<int64_t>(*inpp) + SIGN_EXTEND64((ins & ~lmask) >> (lsb - 2u), 19);
+    int64_t absolute_addr = reinterpret_cast<int64_t>(*inpp) + SIGN_EXTEND64((ins & ~lmask) >> (lsb - 2u), 21);
     int64_t new_pc_offset = static_cast<int64_t>(absolute_addr - reinterpret_cast<int64_t>(*outpp)) >> 2; // shifted
     bool special_fix_type = ctxp->is_in_fixing_range(absolute_addr);
     if (!special_fix_type && llabs(new_pc_offset) >= (~lmask >> (lsb + 1))) {

--- a/And64InlineHook.cpp
+++ b/And64InlineHook.cpp
@@ -168,6 +168,10 @@ static bool __fix_branch_imm(instruction inpp, instruction outpp, context *ctxp)
     return false;
 }
 
+
+static_assert((-1LL >> 1) < 0, "signed arithmetic shift right");
+#define SIGN_EXTEND64(a, sz) (((int64_t)(a) << (64 - (sz))) >> (64 - (sz)))
+
 //-------------------------------------------------------------------------
 
 static bool __fix_cond_comp_test_branch(instruction inpp, instruction outpp, context *ctxp)
@@ -198,7 +202,7 @@ static bool __fix_cond_comp_test_branch(instruction inpp, instruction outpp, con
     } //if
 
     intptr_t current_idx  = ctxp->get_and_set_current_index(*inpp, *outpp);
-    int64_t absolute_addr = reinterpret_cast<int64_t>(*inpp) + ((ins & ~lmask) >> (lsb - 2u));
+    int64_t absolute_addr = reinterpret_cast<int64_t>(*inpp) + SIGN_EXTEND64((ins & ~lmask) >> (lsb - 2u), 19);
     int64_t new_pc_offset = static_cast<int64_t>(absolute_addr - reinterpret_cast<int64_t>(*outpp)) >> 2; // shifted
     bool special_fix_type = ctxp->is_in_fixing_range(absolute_addr);
     if (!special_fix_type && llabs(new_pc_offset) >= (~lmask >> (lsb + 1))) {


### PR DESCRIPTION
指令恢复时对如0x54ff6b28   b.hi   -0x129d 指令做重定向的offset的计算是错误的。
是由于offset imm19是一个signed值，但代码中__fix_cond_comp_test_branch计算absolute_addr将其视为unsigned导致的。